### PR TITLE
Check workspace FileRefs for .xcodeproj extension

### DIFF
--- a/MHImportBuster/External/XcodeEditor/XCWorkspace.m
+++ b/MHImportBuster/External/XcodeEditor/XCWorkspace.m
@@ -57,7 +57,8 @@ static NSString * const XCLocationKey =             @"location";
 }
 
 - (void) addProjectWithFilePath:(NSString *)filePath {
-    if(![[NSFileManager defaultManager] fileExistsAtPath:filePath]) return;
+    if (![filePath mh_containsString:@".xcodeproj"] || ![[NSFileManager defaultManager] fileExistsAtPath:filePath])
+        return;
     
     XCProject *project = [XCProject projectWithFilePath:filePath];
     _projects = [_projects arrayByAddingObject:project];


### PR DESCRIPTION
The plugin crashes if the contents.xcworkspacedata file contains FileRefs which are not Xcode projects (e.g. install_pods.sh).
