### PR TITLE
Added Xcode 7.2 beta 3 UUID.

### DIFF
--- a/MHImportBusterPlugin/MHImportBusterPlugin-Info.plist
+++ b/MHImportBusterPlugin/MHImportBusterPlugin-Info.plist
@@ -39,6 +39,7 @@
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
 		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
+		<string>9AFF134A-08DC-4096-8CEE-62A4BB123046</string>
 	</array>
 	<key>XC4Compatible</key>
 	<true/>


### PR DESCRIPTION
Updated `MHImportBusterPlugin-Info.plist` to include Xcode 7.2 beta 3’s UUID.