### PR TITLE
Added test for equality to a source file's key.

### DIFF
--- a/MHImportBuster/External/XcodeEditor/Categories/XCSourceFile+MHSourceFile.m
+++ b/MHImportBuster/External/XcodeEditor/Categories/XCSourceFile+MHSourceFile.m
@@ -16,7 +16,7 @@
 
 - (BOOL)isEqual:(XCSourceFile *)other {
     return (other == self ||
-            (other.type == self.type && [other.name isEqualToString:self.name]));
+            (other.type == self.type && [other.name isEqualToString:self.name] && [self.key isEqualToString: other.key]));
 }
 
 - (NSString *)lastPathComponent {


### PR DESCRIPTION
Never had an issue, but adding this since you use a file’s key’s hash to compute a source file’s hash.